### PR TITLE
Add Reflection Rate and Projections data

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 import time
 import requests
-from flask import Flask, render_template, send_file, request, session, jsonify
+from flask import Flask, render_template, send_file, request, session, jsonify, Markup
 from flask_mongoengine import MongoEngine
 from flask_restful import reqparse
 from werkzeug.utils import redirect
@@ -17,6 +17,14 @@ import json
 
 mongo = MongoEngine()
 ABI = [{"inputs":[],"stateMutability":"payable","type":"constructor"},{"anonymous":False,"inputs":[{"indexed":True,"internalType":"address","name":"owner","type":"address"},{"indexed":True,"internalType":"address","name":"spender","type":"address"},{"indexed":False,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Approval","type":"event"},{"anonymous":False,"inputs":[{"indexed":False,"internalType":"uint256","name":"minTokensBeforeSwap","type":"uint256"}],"name":"MinTokensBeforeSwapUpdated","type":"event"},{"anonymous":False,"inputs":[{"indexed":True,"internalType":"address","name":"previousOwner","type":"address"},{"indexed":True,"internalType":"address","name":"newOwner","type":"address"}],"name":"OwnershipTransferred","type":"event"},{"anonymous":False,"inputs":[{"indexed":False,"internalType":"uint256","name":"tokensSwapped","type":"uint256"},{"indexed":False,"internalType":"uint256","name":"ethReceived","type":"uint256"},{"indexed":False,"internalType":"uint256","name":"tokensIntoLiqudity","type":"uint256"}],"name":"SwapAndLiquify","type":"event"},{"anonymous":False,"inputs":[{"indexed":False,"internalType":"bool","name":"enabled","type":"bool"}],"name":"SwapAndLiquifyEnabledUpdated","type":"event"},{"anonymous":False,"inputs":[{"indexed":True,"internalType":"address","name":"from","type":"address"},{"indexed":True,"internalType":"address","name":"to","type":"address"},{"indexed":False,"internalType":"uint256","name":"value","type":"uint256"}],"name":"Transfer","type":"event"},{"inputs":[],"name":"_liquidityFee","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"_maxTxAmount","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"_taxFee","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"owner","type":"address"},{"internalType":"address","name":"spender","type":"address"}],"name":"allowance","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"approve","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"balanceOf","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"decimals","outputs":[{"internalType":"uint8","name":"","type":"uint8"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"subtractedValue","type":"uint256"}],"name":"decreaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"tAmount","type":"uint256"}],"name":"deliver","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"excludeFromFee","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"excludeFromReward","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"geUnlockTime","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"includeInFee","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"includeInReward","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"spender","type":"address"},{"internalType":"uint256","name":"addedValue","type":"uint256"}],"name":"increaseAllowance","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"isExcludedFromFee","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"isExcludedFromReward","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"time","type":"uint256"}],"name":"lock","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"name","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"owner","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"pause","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"tAmount","type":"uint256"},{"internalType":"bool","name":"deductTransferFee","type":"bool"}],"name":"reflectionFromToken","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"renounceOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"liquidityFee","type":"uint256"}],"name":"setLiquidityFeePercent","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"maxTxPercent","type":"uint256"}],"name":"setMaxTxPercent","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"setRestrictionAmount","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"bool","name":"_enabled","type":"bool"}],"name":"setSwapAndLiquifyEnabled","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"taxFee","type":"uint256"}],"name":"setTaxFeePercent","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"uint256","name":"time","type":"uint256"}],"name":"setTradingStart","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"swapAndLiquifyEnabled","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"symbol","outputs":[{"internalType":"string","name":"","type":"string"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"uint256","name":"rAmount","type":"uint256"}],"name":"tokenFromReflection","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalFees","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"totalSupply","outputs":[{"internalType":"uint256","name":"","type":"uint256"}],"stateMutability":"view","type":"function"},{"inputs":[{"internalType":"address","name":"recipient","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"transfer","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"sender","type":"address"},{"internalType":"address","name":"recipient","type":"address"},{"internalType":"uint256","name":"amount","type":"uint256"}],"name":"transferFrom","outputs":[{"internalType":"bool","name":"","type":"bool"}],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"newOwner","type":"address"}],"name":"transferOwnership","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"uniswapV2Pair","outputs":[{"internalType":"address","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"uniswapV2Router","outputs":[{"internalType":"contract IUniswapV2Router02","name":"","type":"address"}],"stateMutability":"view","type":"function"},{"inputs":[],"name":"unlock","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[],"name":"unpause","outputs":[],"stateMutability":"nonpayable","type":"function"},{"inputs":[{"internalType":"address","name":"account","type":"address"}],"name":"whitelistAccount","outputs":[],"stateMutability":"nonpayable","type":"function"},{"stateMutability":"payable","type":"receive"}]
+
+credits = """<strong>Clutrack.io</strong> was created by <a target="_blank" href="https://twitter.com/maxbridgland">Max Bridgland</a>
+with a little help from <a target="_blank" href="https://twitter.com/jerisbrisk">Jeremy Anderson</a> and is <strong>NOT</strong>
+affiliated with the CluCoin team. The website content is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>.
+We will never request to withdraw from your account. If you ever get a request that requires you pay gas, reject it!
+<br/>
+<strong>If you find use and want to support the site you can Donate CLU or any ERC/BEP-20 Token to: 0x44f6498D1403321890F3f2917E00F22dBDE3577a</strong>
+"""
 
 def create_app():
     app = Flask(__name__)
@@ -84,10 +92,20 @@ def search():
         longterm_msg = "This address is not linked with CluTrack, long term stats unavailable."
         if holder:
             if holder_bal_count := len(holder.balances) < 12:
-                longterm_msg = "Long term stats will kick in after at least 12 hours of linking. Hours Left: " + str(12 - holder_bal_count)
+                longterm_msg = "Long term stats will be available about 12 hours after you link your account. Hours Left: " + str(12 - holder_bal_count)
             else:
-                longterm_msg = "Long term stats loading..."
-        return render_template('rewards.html', contract=contract, w3=w3, wallet_addr=args.get('address'), Decimal=Decimal, is_logged_in=is_logged, wallet_bal=f"{float(bal):,}", longterm_msg=longterm_msg, conf=conf)
+                longterm_msg = "Loading long term stats..."
+        return render_template(
+            'rewards.html',
+            contract=contract,
+            w3=w3,
+            wallet_addr=args.get('address'),
+            Decimal=Decimal,
+            is_logged_in=is_logged,
+            wallet_bal=f"{float(bal):,}",
+            longterm_msg=longterm_msg,
+            conf=conf,
+            credits=Markup(credits))
     return render_template('index.html', count=len(Holder.objects().all()), conf=conf)
 
 @app.route('/')
@@ -102,7 +120,17 @@ def index():
                 longterm_msg = "Long term stats will kick in after at least 12 hours of linking. Hours Left: " + str(12 - holder_bal_count)
             else:
                 longterm_msg = "Long term stats loading..."
-            return render_template('rewards.html', contract=contract, w3=w3, wallet_addr=holder.address, Decimal=Decimal, wallet_bal=f"{bal:,}", is_logged_in=True, longterm_msg=longterm_msg, conf=conf)
+            return render_template(
+                'rewards.html',
+                contract=contract,
+                w3=w3,
+                wallet_addr=holder.address,
+                Decimal=Decimal,
+                wallet_bal=f"{bal:,}",
+                is_logged_in=True,
+                longterm_msg=longterm_msg,
+                conf=conf,
+                credits=Markup(credits))
     return render_template('index.html', count=len(Holder.objects().all()), conf=conf)
 
 @app.route('/assets/<file>')
@@ -172,7 +200,8 @@ def getRewards(addr):
     lastBal = currentBalance
     bals = []
     block_data = {}
-    while currentBlock - block <= 60:
+
+    while currentBlock - block <= 120:
         try:
             balance = contract.functions.balanceOf(addr).call(block_identifier=block)
             bals.append(w3.fromWei(Decimal(Decimal(lastBal) - Decimal(balance))* (Decimal(10) ** 9), 'ether'))
@@ -181,6 +210,7 @@ def getRewards(addr):
             block -= 1
         except ValueError:
             block -= 1
+
     bal_12hr = {}
     bal_24hr = {}
     total_12hr = 0
@@ -190,6 +220,7 @@ def getRewards(addr):
     lifetime = 0
     has_lifetime = False
     holder = Holder.objects(address=addr).first()
+
     if holder:
         if len(holder.balances) >= 12:
             has_12hr = True
@@ -206,9 +237,7 @@ def getRewards(addr):
         if len(holder.balances) > 0:
             has_lifetime = True
             lifetime = list(holder.balances.values())[-1] - list(holder.balances.values())[0]
-            
 
- 
     return jsonify({
         'avg_br_1m': float(sum(bals[0:20]) / len(bals[0:20])),
         'avg_br_3m': float(sum(bals) / len(bals)),

--- a/app/templates/assets/reward_local.js
+++ b/app/templates/assets/reward_local.js
@@ -23,17 +23,72 @@ function getRewards(addr) {
     }).then((response) => {
         response.json().then(data => {
             var elem = document.getElementById('rewardStats')
+            var avgRewardPerSecond = data.total_reward_3m / 180
+            var rewardPerMinute = avgRewardPerSecond * 60
+            var rewardPerHour = rewardPerMinute * 60
+            var rewardPerDay = rewardPerHour * 24
+            var rewardPerMonth = rewardPerDay * 30
+
             elem.innerHTML = `
             <div class="columns is-desktop">
                 <div class="column is-half">
                     <div class="box">
-                        <p class="subtitle"><strong style="color: black">Total Gained<br>1 Minute</strong></p>
+                        <p class="subtitle">
+                            <strong style="color: black">Reflection Rate</strong><br>
+                            <span style="color: gray">3 Minutes</span>
+                        </p>
+                        <p class="subtitle" style="color: magenta">CLU per Second 🚀` +  numberWithCommas(1 * (avgRewardPerSecond).toPrecision(12)) + `</p>
+                        <p class="subtitle" style="color: green">USD per Second $` +  numberWithCommas(1 * (avgRewardPerSecond * currentPrice).toPrecision(8))  + `</p>
+                        <p style="line-height:50%" />
+                    </div>
+                </div>
+                <div class="column is-half">
+                    <div class="box">
+                        <p class="subtitle">
+                            <strong style="color: black">Projections</strong><br>
+                            <span style="color: gray">CLU per Second * Current Price * Timeframe</span>
+                        </p>
+                        <table class="center" style="text-align:right; width:70%">
+                        <thead style="table-header-group">
+                        <tr>
+                            <th>Timeframe</th>
+                            <th>Projected Value</th>
+                        </tr>
+                        </thead>
+                        <tbody style="display:table-row-group">
+                        <tr>
+                            <td width="50%">per Hour</td>
+                            <td style="color: green">USD $` +  numberWithCommas(1 * (rewardPerHour * currentPrice).toPrecision(8)) + `</td>
+                        </tr>
+                        <tr>
+                            <td width="50%">per Day</td>
+                            <td style="color: green">USD $` +  numberWithCommas(1 * (rewardPerDay * currentPrice).toPrecision(2)) + `</td>
+                        </tr>
+                        <tr>
+                            <td width="50%">per Month</td>
+                            <td style="color: green">USD $` +  numberWithCommas(1 * (rewardPerMonth * currentPrice).toPrecision(2)) + `</td>
+                        </tr>
+                        </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
+            <div class="columns is-desktop">
+                <div class="column is-half">
+                    <div class="box">
+                        <p class="subtitle">
+                            <strong style="color: black">Total Gained</strong><br>
+                            <span style="color: gray">1 Minute</span>
+                        </p>
                         <p class="subtitle" style="color: black">` + numberWithCommas(data.total_reward_1m) + `<br>$` + numberWithCommas(1 * (data.total_reward_1m * currentPrice).toPrecision(12)) + `</p>
                     </div>
                 </div>
                 <div class="column is-half">
                     <div class="box">
-                        <p class="subtitle"><strong style="color: black">Total Gained<br>3 Minutes</strong></p>
+                        <p class="subtitle">
+                            <strong style="color: black">Total Gained</strong><br>
+                            <span style="color: gray">3 Minutes</strong></span>
+                        </p>
                         <p class="subtitle" style="color: black">` + numberWithCommas(data.total_reward_3m) + `<br>$` + numberWithCommas(1 * (data.total_reward_3m * currentPrice).toPrecision(12)) + `</p>
                     </div>
                 </div>

--- a/app/templates/badaddress.html
+++ b/app/templates/badaddress.html
@@ -90,11 +90,7 @@
         <div class="hero-foot">
             <br><br>
             <div class="container has-text-centered">
-                <p>
-                <strong>Clutrack.io</strong> was created by <a href="https://twitter.com/maxbridgland">Max Bridgland</a> and is <strong>NOT</strong> affiliated with the CluCoin team. The website content
-                is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>. We will never request to withdraw from your account. If you ever get a request
-                that requires you pay gas, reject it!
-                </p>
+                <p>{{credits}}</p>
             </div>
         </div>
     </section>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -202,11 +202,7 @@
         <div class="hero-foot">
             <br><br>
             <div class="container has-text-centered">
-                <p>
-                <strong>Clutrack.io</strong> was created by <a href="https://twitter.com/maxbridgland">Max Bridgland</a> and is <strong>NOT</strong> affiliated with the CluCoin team. The website content
-                is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>. We will never request to withdraw from your account. If you ever get a request
-                that requires you pay gas, reject it!
-                </p>
+                <p>{{credits}}</p>
             </div>
         </div>
     </section>

--- a/app/templates/rewards.html
+++ b/app/templates/rewards.html
@@ -116,7 +116,7 @@
                     <hr style="color: rgb(87, 87, 87)">
                     <div id="rewardStats">
                         <p class="subtitle" style="color: black">
-                            Loading Reward Stats...
+                            Loading reward stats...
                         </p>
                     </div>
                     <hr style="color: rgb(87, 87, 87)">
@@ -131,11 +131,7 @@
         </div>
         <div class="hero-foot">
             <div class="container has-text-centered">
-                <p>
-                <strong>Clutrack.io</strong> was created by <a href="https://twitter.com/maxbridgland">Max Bridgland</a> and is <strong>NOT</strong> affiliated with the CluCoin team. The website content
-                is licensed <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/">CC BY NC SA 4.0</a>. We will never request to withdraw from your account. If you ever get a request
-                that requires you pay gas, reject it! <strong>If you find use and want to support the site you can Donate CLU or any ERC/BEP-20 Token to: 0x44f6498D1403321890F3f2917E00F22dBDE3577a</strong>
-                </p>
+                <p>{{credits}}</p>
             </div>
         </div>
     </section>


### PR DESCRIPTION
This change:
1. Adds the `Reflection Rate` and `Projections` report tiles, giving users a glimpse of how quickly CLU is coming in and a Projection for USD earnings, assuming no change in price from the current price.
2. Moves the footer into a new `credits` var that is passed into the Template as `Markup` so it can be injected as HTML
3. Reins in the length of some long lines of code and cleans up some textual inconsistencies observed during testing.

Note, these are very basic calculations and could be made much more sophisticated over time, but for now it's fun to see 'at a glance'.

Some fun wallets to try it with are:

**Clu Community Wallet**
0xf13060282c2Dae0f9DdE3DA0136B17728d487BF2

**Clu Charity Wallet**
0xb8a5D264dB0a25456070755b157D80399342189a